### PR TITLE
Clean dependencies and add CompatHelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,15 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: '00 00 * * *'
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NameResolution"
 uuid = "71a1bf82-56d0-4bbc-8a3c-48b961074391"
 authors = ["thautwarm"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 PrettyPrint = "8162dcfd-2161-5ef2-ae6c-7681170c5f98"

--- a/Project.toml
+++ b/Project.toml
@@ -4,17 +4,14 @@ authors = ["thautwarm"]
 version = "0.1.4"
 
 [deps]
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 PrettyPrint = "8162dcfd-2161-5ef2-ae6c-7681170c5f98"
 
 [compat]
-DataStructures = "^0.17"
 PrettyPrint = "^0.2.0"
 julia = "1"
 
 [extras]
-PrettyPrint = "8162dcfd-2161-5ef2-ae6c-7681170c5f98"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "PrettyPrint"]
+test = ["Test"]


### PR DESCRIPTION
DataStructures 0.18 was released some days ago and we are currently in the process
of updating the DiffEq ecosystem. It's quite tedious since the test dependencies
create quite many cyclic dependencies but ultimately I figured out that one of
the remaining reasons for why tests of, e.g., DiffEqCallbacks currently fail is
that NameResolution is not compatible with DataStructures 0.18.

I noted that DataStructures is actually never imported and hence I just removed it
from the list of dependencies. Additionally, I removed PrettyPrint from the list of
test dependencies since it is already a proper dependency of NameResolution.

Finally, I added CompatHelper to make it easier for you to detect new releases of
dependencies in the future.

It would be great if you could make a new release with these changes :)